### PR TITLE
Fix path parsing after empty added file

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -268,6 +268,13 @@ impl ReviewParser {
                     );
                 }
 
+                if is_diff_header(line) {
+                    self.state = State::FilePreamble(FilePreambleState {
+                        file: parse_diff_header(line)?,
+                    });
+                    return Ok(None);
+                }
+
                 if let Some((mut left_start, mut right_start)) = parse_hunk_start(line)? {
                     // Subtract 1 b/c this line is before the actual diff hunk
                     left_start = left_start.saturating_sub(1);
@@ -655,6 +662,19 @@ mod tests {
             line: LineLocation::Left(58),
             start_line: Some(LineLocation::Left(1)),
             comment: "Comment 1".to_string(),
+        })];
+
+        test(input, &expected);
+    }
+
+    #[test]
+    fn empty_file() {
+        let input = include_str!("../testdata/empty_file");
+        let expected = vec![Comment::Inline(InlineComment {
+            file: "libbpf-cargo/src/test.rs".to_string(),
+            line: LineLocation::Right(2159),
+            start_line: None,
+            comment: "Comment".to_string(),
         })];
 
         test(input, &expected);

--- a/src/review.rs
+++ b/src/review.rs
@@ -146,7 +146,7 @@ impl Review {
         let review_dir = review_path
             .parent()
             .ok_or_else(|| anyhow!("Review path has no parent!"))?;
-        fs::create_dir_all(&review_dir).context("Failed to create workdir directories")?;
+        fs::create_dir_all(review_dir).context("Failed to create workdir directories")?;
 
         // Check if there are unsubmitted changes
         if !force
@@ -185,7 +185,7 @@ impl Review {
             .write(true)
             .create(true)
             .truncate(true)
-            .open(&metadata_path)
+            .open(metadata_path)
             .context("Failed to create metadata file")?;
         metadata_file
             .write_all(json.as_bytes())
@@ -263,7 +263,7 @@ impl Review {
             .write(true)
             .create(true)
             .truncate(true)
-            .open(&metadata_path)
+            .open(metadata_path)
             .context("Failed to create metadata file")?;
         metadata_file
             .write_all(json.as_bytes())

--- a/testdata/empty_file
+++ b/testdata/empty_file
@@ -1,0 +1,39 @@
+> diff --git a/libbpf-cargo/src/btf/btf.rs b/libbpf-cargo/src/btf/btf.rs
+> index 0000000..fffb281 100644
+> --- /dev/null
+> +++ b/libbpf-cargo/src/btf/btf.rs
+> diff --git a/libbpf-cargo/src/test.rs b/libbpf-cargo/src/test.rs
+> index 5b08843..82a0586 100644
+> --- a/libbpf-cargo/src/test.rs
+> +++ b/libbpf-cargo/src/test.rs
+> @@ -2145,3 +2145,27 @@ pub struct __anon_3 {
+>  
+>      assert_definition(&btf, struct_bpf_sock_tuple, expected_output);
+>  }
+> +
+> +#[test]
+> +fn test_btf_dump_float() {
+> +    let prog_text = r#"
+> +float f = 2.16;
+> +double d = 12.15;
+> +"#;
+> +
+> +    let btf = build_btf_prog(prog_text);
+> +
+> +    let f = find_type_in_btf!(btf, Var, "f");
+> +    let d = find_type_in_btf!(btf, Var, "d");
+
+Comment
+
+> +
+> +    assert_eq!(
+> +        "f32",
+> +        btf.type_declaration(f)
+> +            .expect("Failed to generate f decl")
+> +    );
+> +    assert_eq!(
+> +        "f64",
+> +        btf.type_declaration(d)
+> +            .expect("Failed to generate d decl")
+> +    );
+> +}


### PR DESCRIPTION
This input

	> diff --git a/libbpf-cargo/src/btf/btf.rs b/libbpf-cargo/src/btf/btf.rs
	> index 0000000..fffb281 100644
	> --- /dev/null
	> +++ b/libbpf-cargo/src/btf/btf.rs
	> diff --git a/libbpf-cargo/src/test.rs b/libbpf-cargo/src/test.rs
	> index 5b08843..82a0586 100644
	> --- a/libbpf-cargo/src/test.rs
	> +++ b/libbpf-cargo/src/test.rs

the parser treats as the header for the first file.
Fix this by recognizing the second "diff --git" line.

Fixes #23
